### PR TITLE
Add rake task to destroy old sample data

### DIFF
--- a/lib/tasks/sample_records.rake
+++ b/lib/tasks/sample_records.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :sample_records do
+  days = 14
+
+  desc "This task will remove all (specified) sample records on the application older than #{days} days."
+  task remove: :environment do
+    columns_to_check = [Spree::Product, Spree::Order]
+
+    columns_to_check.each do |objects|
+      objects.unscoped.where.not(sample_indicator_id: nil).where('updated_at < ?', DateTime.now - days).destroy_all
+    end
+  end
+end

--- a/spec/tasks/sample_records_spec.rb
+++ b/spec/tasks/sample_records_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'sample_records:remove' do
+  it 'destroys only records that are user generated and abandoned' do
+    Rake.application.rake_require 'tasks/sample_records'
+    # Disabling setting token on save, we're doing that here.
+    allow_any_instance_of(Current).to receive(:token) { Random.hex }
+
+    # User created product, abandoned
+    create(:product).update(updated_at: 30.days.ago)
+    # User created product, active
+    create(:product)
+
+    # To create sample data, we need to not use the token.
+    allow_any_instance_of(Current).to receive(:token) { nil }
+
+    # Sample data, abandoned
+    create(:product).update(updated_at: 30.days.ago)
+
+    expect { Rake::Task['sample_records:remove'].execute }
+      .to change { Spree::Product.unscoped.without_deleted.count }.from(3).to(2)
+  end
+end


### PR DESCRIPTION
Old sample data is bogging the database down. Ideally, we don't want
to destroy records while people are still using the demo, so we'll
only destroy data that hasn't been updated in weeks. Initially,
this only handles orders and products - the bulk of the excess records.
But in the future we may need to expand this to other records, as I
imagine the lesser used records will pile up over time (and really,
our available usage is only like ~1000-3000 records)

When this gets merged, I need to remember to add this to the Heroku Scheduler!