### PR TITLE
Add filename check to avoid cloudinary breakage

### DIFF
--- a/app/overrides/spree/admin/taxons/attachment_forms/paperclip/add_filename_check.rb
+++ b/app/overrides/spree/admin/taxons/attachment_forms/paperclip/add_filename_check.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: 'spree/admin/taxons/attachment_forms/paperclip/add_filename_check',
+  virtual_path: 'spree/admin/taxons/attachment_forms/_paperclip',
+  original: 'c15d7457875dbbce987638e26fe548e5b9415160',
+  surround: 'erb[silent]:contains("if f.object.send(attachment).exists?")',
+  text: '
+    <% if !f.object.send(attachment).original_filename.nil? %>
+      <%= render_original %>
+    <% end %>
+  '
+)


### PR DESCRIPTION
The cloudinary paperclip gem is a bit out of date, and is missing
a check to see if the filename exists before using it for important
things. This leads to the taxons attachment form breaking. This
adds that check in!

closes #69 