### PR TITLE
Fix stock item locking with unpersisted changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "solidus_starter_frontend", git: 'https://github.com/nebulab/solidus_starter
 gem "solidus_user_guides", git: 'https://github.com/seand7565/solidus_user_guides'
 gem "solidus_paypal_commerce_platform", git: 'https://github.com/nebulab/solidus_paypal_commerce_platform'
 
+gem 'prependers'
+
 group :heroku do
   gem 'cloudinary', '~> 1.11'
   gem 'paperclip-cloudinary'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,7 @@ GEM
       activerecord (>= 5.2.1)
     polyglot (0.3.5)
     popper_js (1.16.0)
+    prependers (1.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -457,6 +458,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   paperclip-cloudinary
   pg
+  prependers
   pry
   puma
   rails (~> 6.0.3)

--- a/app/prependers/models/solidus_demo/spree/stock_item/unlock_sample_data.rb
+++ b/app/prependers/models/solidus_demo/spree/stock_item/unlock_sample_data.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusDemo
+  module Spree
+    module StockItem
+      module UnlockSampleData
+        def with_lock
+          return super if sample_indicator_id
+
+          yield
+        end
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,3 +40,6 @@ module SolidusDemo
     # the framework and any gems in your application.
   end
 end
+
+# Load prependers automatically from app/prependers.
+Prependers.setup_for_rails(namespace: SolidusDemo)

--- a/spec/features/stock_item_lock_spec.rb
+++ b/spec/features/stock_item_lock_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'stock item lock', type: :feature do
+  it 'works on sample data with unpersisted changes' do
+    stock_item = create(:stock_item)
+    stock_item.backorderable = false
+
+    expect { stock_item.adjust_count_on_hand(12) }.to change { stock_item.count_on_hand }.by 12
+  end
+
+  it 'fails on user created data with unpersisted changes' do
+    stock_item = create(:stock_item)
+    stock_item.update(sample_indicator_id: Random.hex)
+    stock_item.backorderable = false
+
+    expect { stock_item.adjust_count_on_hand(12) }.to raise_error(RuntimeError)
+  end
+end


### PR DESCRIPTION
Currently there's a bug where if you check out using the same sample
product variant twice, you'll trigger a runtime error. This is because
when you "edit" sample data, what you're actually doing is creating
a SampleChange where that change is stored. The next time you fetch
the thing you tried to change, the SampleChange you made will be loaded
in with it, and whatever you changed will be swapped in.

This swap isn't persisted though, and so when StockItem has `with_lock`
called on it and there's already a SampleChange associated with it,
the unpersisted data causes this error.

Since we're not actually saving anything on the stock_item, I've
disabled with_lock for changes as long as it's sample data.
Everything else will be locked as normal!

closes: #50 

https://www.loom.com/share/3fd6990b659a434fa40974f8893aa72d