### PR TITLE
Allow db:reset even if the db is being accessed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,7 +215,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/lib/force_db_drop.rb
+++ b/lib/force_db_drop.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter < AbstractAdapter
+      def drop_database(name)
+        execute <<-SQL
+          UPDATE pg_catalog.pg_database
+          SET datallowconn=false WHERE datname='#{name}'
+        SQL
+
+        execute <<-SQL
+          SELECT pg_terminate_backend(pg_stat_activity.pid)
+          FROM pg_stat_activity
+          WHERE pg_stat_activity.datname = '#{name}';
+        SQL
+        execute "DROP DATABASE IF EXISTS #{quote_table_name(name)}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to reset the application everyday so that we don't cramp up the database with useless data.

By default Rails and Postgres won't allow for destructive behavior if the db is being accessed. This is required so that the db can be reset regardless of access.