### PR TITLE
Configure CORS policy to allow the GraphQL playground

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+# CORS policy
+gem 'rack-cors', '~> 1.1'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,8 @@ GEM
     rack (2.2.3)
     rack-attack (6.3.1)
       rack (>= 1.0, < 3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.4)
@@ -475,6 +477,7 @@ DEPENDENCIES
   pry
   puma
   rack-attack
+  rack-cors (~> 1.1)
   rails (~> 6.0.3)
   rb-readline
   rspec-rails

--- a/config/initializers/rack_cors.rb
+++ b/config/initializers/rack_cors.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins [ENV['GRAPHQL_PLAYGROUND_ORIGIN']].compact
+    resource '/graphql', headers: :any, methods: %i[post]
+  end
+end


### PR DESCRIPTION
Prepare the app to act as a server for the GraphQL playground site. For
now, the endpoint is
`https://solidemo-graphql-playground.herokuapp.com`, which is under an
application I own on Heroku, but we should change both the domain name
and ownership once we're ready to publicize it.

See #89