### PR TITLE
Allow setting GRAPHQL_PLAYGROUND_ORIGIN env when waking up docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       DB_HOST: postgres
       HISTFILE: "/home/solidus_demo_user/history/bash_history"
       CAPYBARA_JS_DRIVER: apparition_docker_friendly
+      GRAPHQL_PLAYGROUND_ORIGIN: "${GRAPHQL_PLAYGROUND_ORIGIN:-http://localhost:4000}"
     ports:
       - "${SAMPLE_PORT:-3000}:${SAMPLE_PORT:-3000}"
     volumes:


### PR DESCRIPTION
It allows setting the environment variable like this:

```bash
GRAPHQL_PLAYGROUND_ORIGIN=http://localhost:8800 docker-compose up -d
```

It defaults to `http://localhost:4000`, which matches the default set on
the GraphQL playground site on development.