### PR TITLE
Fix cart link bubble

### DIFF
--- a/app/monkey_patches/spree/base_helper_monkey_patch.rb
+++ b/app/monkey_patches/spree/base_helper_monkey_patch.rb
@@ -1,5 +1,5 @@
 module Spree
-  module UpdateCartLink
+  module BaseHelper
     def link_to_cart(text = nil)
       text = text ? h(text) : t('spree.cart')
       css_class = nil
@@ -14,7 +14,5 @@ module Spree
       end
       link_to text.html_safe, spree.cart_path, class: "cart-info #{css_class}"
     end
-
-    BaseHelper.prepend(UpdateCartLink)
   end
 end


### PR DESCRIPTION
Expected behavior
-----------------

Given the cart has items
When I view the cart
Then I should see that it has a bubble with the number of items on it

![image](https://user-images.githubusercontent.com/61476/145502845-8987444b-7929-4be1-b1a1-0ec657af5fad.png)


Actual behavior
---------------

The cart link shows the text "CART: (`<count>`)" on top of the cart icon.
It also shows the cart total amount.

![image](https://user-images.githubusercontent.com/61476/145502898-4897251b-ef49-4388-817e-fbc2b0745112.png)

Cause
-----

In `app/monkey_patches/spree/base_helper_monkey_patch.rb`, it seems that
prepending the module with the modified `link_to_cart` helper to
`Spree::BaseHelper` does not work as expected.

Demo
----

https://www.loom.com/share/80d1c4578ed349d99240377d5de9f058