### PR TITLE
Removes markup from text.

### DIFF
--- a/lib/tour.yml
+++ b/lib/tour.yml
@@ -6,7 +6,7 @@ spree/home:
       body_text: |+
         Welcome to the Solidus Guided Tour. We'll take you through some of what we think makes Solidus special.
 
-        Buckle up and get ready, and click the "Next" button on the right to begin!{strong:bold text'}
+        Buckle up and get ready, and click the "Next" button on the right to begin!
     customize:
       button_action: next
       title: Fully Customizable


### PR DESCRIPTION
Removes this buggy markup from the text.

<img width="920" alt="Bildschirmfoto 2022-01-11 um 09 24 58" src="https://user-images.githubusercontent.com/69770/148966905-86c75eb7-bc1c-4bf7-951b-b3d43ccda281.png">
 