### PR TITLE
Add notification banner for upcoming redesign

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -8,6 +8,9 @@ $color-green-light: #90dfad;
 $color-gray: #f2f2f2;
 $color-gray-light: #ececec;
 $color-gray-lighter: #fafbfc;
+$color-orange: #f97316;
+$color-orange-light: #fffaef;
+$color-orange-text: #c05621;
 
 // Typo
 $font-size-base: 14px;
@@ -30,3 +33,10 @@ $toggler-height: 50px;
 $toggler-height-open: 28px;
 $widget-inner-height: 90px;
 $widget-body-height: 136px;
+
+// Notification banner
+$notification-padding: 16px;
+$notification-border: 1px solid $color-orange;
+$notification-bp-smallest: 420px;
+$notification-bp-small: 525px;
+$notification-bp-medium: 862px;

--- a/app/assets/stylesheets/components/notification/_banner.scss
+++ b/app/assets/stylesheets/components/notification/_banner.scss
@@ -1,0 +1,28 @@
+@import "../../variables";
+
+.notification-banner {
+  background-color: $color-orange-light;
+  color: $color-orange-text;
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  padding: $notification-padding;
+  text-align: center;
+  border-bottom: $notification-border;
+
+  a {
+    color: $color-orange-text;
+    opacity: 0.8;
+    text-decoration: underline;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  @media (max-width: $notification-bp-small) {
+    padding: $spacer / 3;
+  }
+}

--- a/app/assets/stylesheets/components/user_tour/_widget.scss
+++ b/app/assets/stylesheets/components/user_tour/_widget.scss
@@ -5,7 +5,20 @@
   font-size: $font-size-base;
   line-height: $line-height-base;
   background-color: $color-gray-lighter;
-  
+  padding-top: 58px;
+
+  @media (max-width: $notification-bp-medium) {
+    padding-top: 84px;
+  }
+
+  @media (max-width: $notification-bp-small) {
+    padding-top: 62px;
+  }
+
+  @media (max-width: $notification-bp-smallest) {
+    padding-top: 87px;
+  }
+
   .tour-body {
     color: $font-color-base;
     height: 0;

--- a/app/assets/stylesheets/demo_style.css.scss
+++ b/app/assets/stylesheets/demo_style.css.scss
@@ -35,4 +35,6 @@
 
 @import "components/search/search_bar";
 
+@import "components/notification/banner";
+
 @import "general/utilities";

--- a/app/overrides/spree/layouts/spree_application/add_new_design_notification_banner.html.erb.deface
+++ b/app/overrides/spree/layouts/spree_application/add_new_design_notification_banner.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_after 'title'  -->
+
+<%= render partial: 'spree/shared/notification_banner' %>

--- a/app/views/spree/shared/_notification_banner.html.erb
+++ b/app/views/spree/shared/_notification_banner.html.erb
@@ -1,0 +1,3 @@
+<div class="notification-banner">
+    🚧 We are rebuilding this demo after our rebrand! In the meantime, check out <a href="https://solidus.io/" target="_blank" rel="noopener noreferrer">our website</a> for more information.
+</div>


### PR DESCRIPTION
## Summary

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.



  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

Fixes #137 
 
This PR introduces a fixed header banner on the Solidus demo. The main aim is to inform users about our upcoming design overhaul.

https://github.com/solidusio/solidus-demo/assets/19948291/682bf03e-0ae2-4974-b0e4-be1da54dc391

<img width="1840" alt="Screenshot 2023-08-18 at 13 40 14" src="https://github.com/solidusio/solidus-demo/assets/19948291/5faedf85-55db-4b84-bd7b-0da3edb39d82">
<img width="976" alt="Screenshot 2023-08-18 at 13 40 19" src="https://github.com/solidusio/solidus-demo/assets/19948291/c7719f49-9eb3-43fb-9522-cb62115447ce">
<img width="612" alt="Screenshot 2023-08-18 at 13 40 23" src="https://github.com/solidusio/solidus-demo/assets/19948291/fa9911af-d439-49a8-a561-3595ddc92711">




## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
